### PR TITLE
Updated from haproxy 1.9 to 2.0 and enabled logging to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN \
   tar -zxvf /tmp/haproxy.tgz -C /tmp && \
   cd /tmp/haproxy-* && \
   make \
-    TARGET=linux2628 USE_LINUX_TPROXY=1 USE_ZLIB=1 USE_REGPARM=1 USE_PCRE=1 USE_PCRE_JIT=1 \
+    TARGET=linux-glibc USE_LINUX_TPROXY=1 USE_ZLIB=1 USE_REGPARM=1 USE_PCRE=1 USE_PCRE_JIT=1 \
     USE_OPENSSL=1 SSL_INC=/usr/include SSL_LIB=/usr/lib ADDLIB=-ldl \
     CFLAGS="-O2 -g -fno-strict-aliasing -DTCP_USER_TIMEOUT=18" && \
   make install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:centos7
 
-ENV   HAPROXY_MJR_VERSION=1.9 \
-      HAPROXY_VERSION=1.9.2 \
+ENV   HAPROXY_MJR_VERSION=2.0 \
+      HAPROXY_VERSION=2.0.8 \
       HAPROXY_CONFIG='/etc/haproxy/haproxy.cfg' \
       HAPROXY_ADDITIONAL_CONFIG='' \
       HAPROXY_PRE_RESTART_CMD='' \

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Example:
 
 ```bash
 docker run -ti \
-  --cap-add NET_ADMIN \
   -p 80:80 \
   -p 443:443 \
   million12/haproxy
@@ -57,7 +56,6 @@ docker run -ti \
 
 ```bash
 docker run -d \
-  --cap-add NET_ADMIN \
   -p 80:80 \
   -v /my-haproxy.cfg:/etc/haproxy/haproxy.cfg \
   million12/haproxy \
@@ -70,7 +68,6 @@ Note: in this case config is mounted to its default location, so you don't need 
 
 ```bash
 docker run -d \
-  --cap-add NET_ADMIN \
   -p 80:80 \
   -e HAPROXY_ADDITIONAL_CONFIG='/etc/haproxy/custom1 /etc/haproxy/custom2' \
   million12/haproxy

--- a/container-files/bootstrap.sh
+++ b/container-files/bootstrap.sh
@@ -75,7 +75,7 @@ while inotifywait -q -e create,delete,modify,attrib /etc/hosts $HAPROXY_CONFIG $
   log "Executing pre-restart hook..."
   $HAPROXY_PRE_RESTART_CMD
   log "Restarting haproxy..."
-  $HAPROXY_CMD -sf $HAPROXY_PID
+  $HAPROXY_CMD -sf $HAPROXY_PID &
   HAPROXY_PID=$!
   log "Got new PID: $HAPROXY_PID"
   log "Executing post-restart hook..."

--- a/container-files/bootstrap.sh
+++ b/container-files/bootstrap.sh
@@ -42,7 +42,7 @@ print_config() {
 
 # Check iptables rules modification capabilities
 $LIST_IPTABLES > /dev/null 2>&1
-# Exit immidiately in case of any errors
+# Exit immediately in case of any errors
 if [[ $? != 0 ]]; then
     EXIT_CODE=$?;
     echo "Please enable NET_ADMIN capabilities by passing '--cap-add NET_ADMIN' parameter to docker run command";
@@ -61,7 +61,7 @@ $HAPROXY_CMD &
 
 HAPROXY_PID=$!
 
-# Exit immidiately in case of any errors or when we have interactive terminal
+# Exit immediately in case of any errors or when we have interactive terminal
 if [[ $? != 0 ]] || test -t 0; then exit $?; fi
 log "HAProxy started with $HAPROXY_CONFIG config, pid $HAPROXY_PID." && log
 
@@ -77,6 +77,7 @@ while inotifywait -q -e create,delete,modify,attrib /etc/hosts $HAPROXY_CONFIG $
   log "Restarting haproxy..."
   $HAPROXY_CMD -sf $HAPROXY_PID
   HAPROXY_PID=$!
+  log "Got new PID: $HAPROXY_PID"
   log "Executing post-restart hook..."
   $HAPROXY_POST_RESTART_CMD
   $DISABLE_SYN_DROP

--- a/container-files/bootstrap.sh
+++ b/container-files/bootstrap.sh
@@ -76,6 +76,7 @@ while inotifywait -q -e create,delete,modify,attrib /etc/hosts $HAPROXY_CONFIG $
   $HAPROXY_PRE_RESTART_CMD
   log "Restarting haproxy..."
   $HAPROXY_CMD -sf $HAPROXY_PID
+  HAPROXY_PID=$!
   log "Executing post-restart hook..."
   $HAPROXY_POST_RESTART_CMD
   $DISABLE_SYN_DROP

--- a/container-files/bootstrap.sh
+++ b/container-files/bootstrap.sh
@@ -12,7 +12,7 @@ HAPROXY_USER_PARAMS=$@
 
 # Internal params
 HAPROXY_PID_FILE="/var/run/haproxy.pid"
-HAPROXY_CMD="/usr/local/sbin/haproxy -f ${HAPROXY_CONFIG} ${HAPROXY_USER_PARAMS} -D -p ${HAPROXY_PID_FILE}"
+HAPROXY_CMD="/usr/local/sbin/haproxy -f ${HAPROXY_CONFIG} ${HAPROXY_USER_PARAMS} -p ${HAPROXY_PID_FILE}"
 HAPROXY_CHECK_CONFIG_CMD="/usr/local/sbin/haproxy -f ${HAPROXY_CONFIG} -c"
 
 # Iptable commands
@@ -58,7 +58,7 @@ grep --silent -e "web.server" /etc/hosts || echo "127.0.0.1 web.server" >> /etc/
 
 log $HAPROXY_CMD && print_config
 $HAPROXY_CHECK_CONFIG_CMD
-$HAPROXY_CMD
+$HAPROXY_CMD &
 # Exit immidiately in case of any errors or when we have interactive terminal
 if [[ $? != 0 ]] || test -t 0; then exit $?; fi
 log "HAProxy started with $HAPROXY_CONFIG config, pid $(cat $HAPROXY_PID_FILE)." && log


### PR DESCRIPTION
Logging to stdout is enabled by keeping process in foreground instead of using daemon mode